### PR TITLE
11.0 caf msm8998

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -353,8 +353,7 @@ endif
 LOCAL_CFLAGS += -D_GNU_SOURCE
 LOCAL_CFLAGS += -Wall -Werror
 
-LOCAL_COPY_HEADERS_TO   := mm-audio
-LOCAL_COPY_HEADERS      := audio_extn/audio_defs.h
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_GCOV)),true)
     LOCAL_CFLAGS += --coverage -fprofile-arcs -ftest-coverage

--- a/mm-audio/aenc-aac/qdsp6/Android.mk
+++ b/mm-audio/aenc-aac/qdsp6/Android.mk
@@ -24,7 +24,6 @@ libOmxAacEnc-def += -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-self-assign 
 include $(CLEAR_VARS)
 
 libOmxAacEnc-inc       := $(LOCAL_PATH)/inc
-libOmxAacEnc-inc       += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 
 LOCAL_MODULE             := libOmxAacEnc
 LOCAL_MODULE_TAGS        := optional
@@ -46,11 +45,10 @@ endif
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/techpack/audio/include
 LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+
+LOCAL_HEADER_LIBRARIES := libomxcore_headers
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
-endif
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
+  LOCAL_HEADER_LIBRARIES += audio_kernel_headers
   LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/vendor/qcom/opensource/audio-kernel/include
 endif
 
@@ -64,7 +62,6 @@ include $(CLEAR_VARS)
 
 mm-aac-enc-test-inc    := $(LOCAL_PATH)/inc
 mm-aac-enc-test-inc    += $(LOCAL_PATH)/test
-mm-aac-enc-test-inc    += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 
 LOCAL_MODULE            := mm-aenc-omxaac-test
 LOCAL_MODULE_TAGS       := optional

--- a/mm-audio/aenc-amrnb/qdsp6/Android.mk
+++ b/mm-audio/aenc-amrnb/qdsp6/Android.mk
@@ -25,7 +25,6 @@ libOmxAmrEnc-def += -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-self-assign 
 include $(CLEAR_VARS)
 
 libOmxAmrEnc-inc       := $(LOCAL_PATH)/inc
-libOmxAmrEnc-inc       += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 
 LOCAL_MODULE             := libOmxAmrEnc
 LOCAL_MODULE_TAGS        := optional
@@ -48,11 +47,9 @@ endif
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/techpack/audio/include
 LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+LOCAL_HEADER_LIBRARIES := libomxcore_headers
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
-endif
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
+  LOCAL_HEADER_LIBRARIES += audio_kernel_headers
   LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/vendor/qcom/opensource/audio-kernel/include
 endif
 
@@ -67,7 +64,6 @@ include $(CLEAR_VARS)
 mm-amr-enc-test-inc    := $(LOCAL_PATH)/inc
 mm-amr-enc-test-inc    += $(LOCAL_PATH)/test
 
-mm-amr-enc-test-inc    += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 LOCAL_MODULE            := mm-aenc-omxamr-test
 LOCAL_MODULE_TAGS       := optional
 LOCAL_CFLAGS            := $(libOmxAmrEnc-def)

--- a/mm-audio/aenc-evrc/qdsp6/Android.mk
+++ b/mm-audio/aenc-evrc/qdsp6/Android.mk
@@ -25,7 +25,6 @@ libOmxEvrcEnc-def += -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-self-assign
 include $(CLEAR_VARS)
 
 libOmxEvrcEnc-inc       := $(LOCAL_PATH)/inc
-libOmxEvrcEnc-inc       += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 
 LOCAL_MODULE             := libOmxEvrcEnc
 LOCAL_MODULE_TAGS        := optional
@@ -48,11 +47,9 @@ endif
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/techpack/audio/include
 LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+LOCAL_HEADER_LIBRARIES := libomxcore_headers
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
-endif
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
+  LOCAL_HEADER_LIBRARIES += audio_kernel_headers
   LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/vendor/qcom/opensource/audio-kernel/include
 endif
 
@@ -66,7 +63,7 @@ include $(CLEAR_VARS)
 
 mm-evrc-enc-test-inc    := $(LOCAL_PATH)/inc
 mm-evrc-enc-test-inc    += $(LOCAL_PATH)/test
-mm-evrc-enc-test-inc    += $(TARGET_OUT_HEADERS)/mm-core/omxcore
+
 LOCAL_MODULE            := mm-aenc-omxevrc-test
 LOCAL_MODULE_TAGS       := optional
 LOCAL_CFLAGS            := $(libOmxEvrcEnc-def)

--- a/mm-audio/aenc-g711/qdsp6/Android.mk
+++ b/mm-audio/aenc-g711/qdsp6/Android.mk
@@ -25,7 +25,6 @@ libOmxG711Enc-def += -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-self-assign
 include $(CLEAR_VARS)
 
 libOmxG711Enc-inc       := $(LOCAL_PATH)/inc
-libOmxG711Enc-inc       += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 
 LOCAL_MODULE             := libOmxG711Enc
 LOCAL_MODULE_TAGS        := optional
@@ -49,11 +48,9 @@ endif
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/techpack/audio/include
 LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+LOCAL_HEADER_LIBRARIES := libomxcore_headers
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
-endif
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
+  LOCAL_HEADER_LIBRARIES += audio_kernel_headers
   LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/vendor/qcom/opensource/audio-kernel/include
 endif
 
@@ -69,7 +66,6 @@ include $(CLEAR_VARS)
 
 mm-g711-enc-test-inc   := $(LOCAL_PATH)/inc
 mm-g711-enc-test-inc   += $(LOCAL_PATH)/test
-mm-g711-enc-test-inc   += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 
 LOCAL_MODULE            := mm-aenc-omxg711-test
 LOCAL_MODULE_TAGS       := optional

--- a/mm-audio/aenc-qcelp13/qdsp6/Android.mk
+++ b/mm-audio/aenc-qcelp13/qdsp6/Android.mk
@@ -25,7 +25,6 @@ libOmxQcelp13Enc-def += -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-self-ass
 include $(CLEAR_VARS)
 
 libOmxQcelp13Enc-inc       := $(LOCAL_PATH)/inc
-libOmxQcelp13Enc-inc       += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 
 LOCAL_MODULE             := libOmxQcelp13Enc
 LOCAL_MODULE_TAGS        := optional
@@ -48,11 +47,9 @@ endif
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/techpack/audio/include
 LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+LOCAL_HEADER_LIBRARIES := libomxcore_headers
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
-endif
-ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)
-  LOCAL_HEADER_LIBRARIES := audio_kernel_headers
+  LOCAL_HEADER_LIBRARIES += audio_kernel_headers
   LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/vendor/qcom/opensource/audio-kernel/include
 endif
 
@@ -69,7 +66,6 @@ include $(CLEAR_VARS)
 mm-qcelp13-enc-test-inc    := $(LOCAL_PATH)/inc
 mm-qcelp13-enc-test-inc    += $(LOCAL_PATH)/test
 
-mm-qcelp13-enc-test-inc    += $(TARGET_OUT_HEADERS)/mm-core/omxcore
 LOCAL_MODULE            := mm-aenc-omxqcelp13-test
 LOCAL_MODULE_TAGS       := optional
 LOCAL_CFLAGS            := $(libOmxQcelp13Enc-def)

--- a/qahw/Android.mk
+++ b/qahw/Android.mk
@@ -5,11 +5,9 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-libqahw-inc := $(LOCAL_PATH)/inc
-
 LOCAL_MODULE := libqahwwrapper
 LOCAL_MODULE_TAGS := optional
-LOCAL_C_INCLUDES   := $(libqahw-inc)
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/inc
 
 LOCAL_SRC_FILES := \
     src/qahw.c \
@@ -23,19 +21,17 @@ LOCAL_SHARED_LIBRARIES := \
 
 LOCAL_CFLAGS += -Wall -Werror
 
-LOCAL_COPY_HEADERS_TO   := mm-audio/qahw/inc
-LOCAL_COPY_HEADERS      := inc/qahw.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_api.h
-
 LOCAL_PRELINK_MODULE    := false
 LOCAL_VENDOR_MODULE     := true
 
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
-LOCAL_COPY_HEADERS_TO   := mm-audio/qahw_api/inc
-LOCAL_COPY_HEADERS      := inc/qahw_defs.h
 
-include $(BUILD_COPY_HEADERS)
+LOCAL_MODULE := libqahw_headers
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/inc
+LOCAL_PROPRIETARY_MODULE := true
+
+include $(BUILD_HEADER_LIBRARY)
 endif
 endif

--- a/qahw_api/Android.mk
+++ b/qahw_api/Android.mk
@@ -4,12 +4,9 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-libqahwapi-inc := $(LOCAL_PATH)/inc
-
 LOCAL_MODULE := libqahw
 LOCAL_MODULE_TAGS := optional
-LOCAL_C_INCLUDES   := $(libqahwapi-inc)
-LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/mm-audio/qahw/inc
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/inc
 
 LOCAL_SRC_FILES := \
     src/qahw_api.cpp
@@ -20,6 +17,9 @@ LOCAL_CPPFLAGS += --coverage -fprofile-arcs -ftest-coverage
 LOCAL_STATIC_LIBRARIES += libprofile_rt
 endif
 
+LOCAL_HEADER_LIBRARIES := \
+    libqahw_headers
+
 LOCAL_SHARED_LIBRARIES := \
     liblog \
     libcutils \
@@ -29,20 +29,18 @@ LOCAL_SHARED_LIBRARIES := \
 
 LOCAL_CFLAGS += -Wall -Werror
 
-LOCAL_COPY_HEADERS_TO   := mm-audio/qahw_api/inc
-LOCAL_COPY_HEADERS      := inc/qahw_api.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_audiosphere.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_bassboost.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_environmentalreverb.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_equalizer.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_presetreverb.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_virtualizer.h
-LOCAL_COPY_HEADERS      += inc/qahw_effect_visualizer.h
-
 LOCAL_PRELINK_MODULE    := false
 LOCAL_VENDOR_MODULE     := true
 
 include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libqahwapi_headers
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/inc
+LOCAL_PROPRIETARY_MODULE := true
+
+include $(BUILD_HEADER_LIBRARY)
 
 #test app compilation
 include $(LOCAL_PATH)/test/Android.mk

--- a/qahw_api/test/Android.mk
+++ b/qahw_api/test/Android.mk
@@ -7,11 +7,13 @@ LOCAL_SRC_FILES := qahw_playback_test.c \
                    qahw_effect_test.c
 LOCAL_MODULE := hal_play_test
 
-hal-play-inc     = $(TARGET_OUT_HEADERS)/mm-audio/qahw_api/inc
-hal-play-inc    += $(TARGET_OUT_HEADERS)/mm-audio/qahw/inc
 hal-play-inc    += external/tinyalsa/include
 
 LOCAL_CFLAGS += -Wall -Werror -Wno-sign-compare
+
+LOCAL_HEADER_LIBRARIES := \
+    libqahw_headers \
+    libqahwapi_headers
 
 LOCAL_SHARED_LIBRARIES := \
     libaudioutils\
@@ -39,6 +41,10 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := qahw_multi_record_test.c
 LOCAL_MODULE := hal_rec_test
 LOCAL_CFLAGS += -Wall -Werror -Wno-sign-compare
+
+LOCAL_HEADER_LIBRARIES := \
+    libqahwapi_headers
+
 LOCAL_SHARED_LIBRARIES := \
     libaudioutils \
     libqahw \
@@ -46,9 +52,6 @@ LOCAL_SHARED_LIBRARIES := \
 
 LOCAL_32_BIT_ONLY := true
 
-hal-rec-inc     = $(TARGET_OUT_HEADERS)/mm-audio/qahw_api/inc
-
-LOCAL_C_INCLUDES += $(hal-rec-inc)
 LOCAL_VENDOR_MODULE := true
 
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
LOCAL_COPY_HEADERS is deprecated, so remove all its usages to avoid build warnings.
hal: use omx core headers as a header library needed for build